### PR TITLE
fix: 'prending' filter not being selected by default

### DIFF
--- a/frontend/vizzy/app/dashboard/dashboard-page-client.tsx
+++ b/frontend/vizzy/app/dashboard/dashboard-page-client.tsx
@@ -21,7 +21,7 @@ export default function DashboardPageClient() {
     { id: "accepted", label: "Accepted", checked: false },
     { id: "rejected", label: "Rejected", checked: false },
     { id: "canceled", label: "Cancelled", checked: false },
-    { id: "pending", label: "Pending", checked: false },
+    { id: "pending", label: "Pending", checked: true },
   ])
   const [filterDropdownOpen, setFilterDropdownOpen] = useState(false)
 

--- a/frontend/vizzy/app/dashboard/layout/proposals-page.tsx
+++ b/frontend/vizzy/app/dashboard/layout/proposals-page.tsx
@@ -49,7 +49,7 @@ export function ProposalsPage({ filterOptions = [], hasActiveFilters }: Proposal
             accepted: false,
             rejected: false,
             canceled: false,
-            pending: true,
+            pending: false,
           }
         )
 


### PR DESCRIPTION
Fixed a bug where the 'pending' filter on the proposals bage was not being selected by default