### PR TITLE
refactor: cancel proposal endpoint and frontend api call

### DIFF
--- a/frontend/vizzy/components/proposals/cancel-proposal-dialog.tsx
+++ b/frontend/vizzy/components/proposals/cancel-proposal-dialog.tsx
@@ -13,7 +13,7 @@ import {
 } from '@/components/ui/overlay/alert-dialog';
 import { Button } from '@/components/ui/common/button';
 import { Trash2 } from 'lucide-react';
-import { updateProposalStatus } from '@/lib/api/proposals/update-proposal-status';
+import { cancelProposal } from '@/lib/api/proposals/cancel-proposal';
 
 interface CancelProposalDialogProps {
   proposalId: number;
@@ -24,7 +24,7 @@ export function CancelProposalDialog({ proposalId, onConfirm }: CancelProposalDi
   console.log('Dialog opened with proposalId:', proposalId);
   const handleCancel = async () => {
     try {
-      await updateProposalStatus('cancelled', proposalId);
+      await cancelProposal(proposalId);
       console.log(`Proposal ${proposalId} status updated to canceled.`);
       onConfirm?.();
       window.location.reload();

--- a/frontend/vizzy/lib/api/proposals/cancel-proposal.ts
+++ b/frontend/vizzy/lib/api/proposals/cancel-proposal.ts
@@ -1,0 +1,22 @@
+import { apiRequest } from '@/lib/api/core/client';
+import { tryCatch, type Result } from '@/lib/utils/try-catch';
+import { getAuthTokensAction } from '@/lib/actions/auth/token-action';
+
+export async function cancelProposal(
+  proposalId: number,
+): Promise<Result<void>> {
+  return tryCatch(
+    (async () => {
+      const { accessToken } = await getAuthTokensAction();
+      if (!accessToken) {
+        throw new Error('Authentication required');
+      }
+
+      return apiRequest<void>({
+        method: 'PATCH',
+        endpoint: `proposals/${proposalId}/cancel`,
+        token: accessToken,
+      });
+    })(),
+  );
+}


### PR DESCRIPTION
Rework on the backend to create a new endpoint tha exclusively allows the sender to cancel a proposal. Also updated the frontend call.